### PR TITLE
Basic QOL stuff i added while digging through tags

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -363,5 +363,6 @@
             <Button x:Name="SaveAndCloseButton" Content="Save &amp; Close" HorizontalAlignment="Left" Margin="90,6,0,0" VerticalAlignment="Top" Width="75" Background="#FF1E1E1E" Foreground="#FFC8C8C8" BorderBrush="#FF646464" Click="SaveAndCloseButton_Click" Visibility="Hidden" Template="{DynamicResource ButtonControlTemplate}"/>
             <Button x:Name="CloseButton" Content="Close" HorizontalAlignment="Left" Margin="170,6,0,0" VerticalAlignment="Top" Width="75" Background="#FF1E1E1E" Foreground="#FFC8C8C8" BorderBrush="#FF646464" Click="CloseButton_Click" Visibility="Hidden" Template="{DynamicResource ButtonControlTemplate}"/>
         </Grid>
+        <GridSplitter HorizontalAlignment="Left" Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" VerticalAlignment="Stretch" Width="4" Background="#FF3C3C3C" Margin="-2,0,0,0"/>
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -66,14 +66,21 @@ namespace InfiniteModuleEditor
                     else
                         return;
                 }
-                ModuleStream = new FileStream(ofd.FileName, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
-                Module = ModuleEditor.ReadModule(ModuleStream);
-                TagList.ItemsSource = Module.ModuleFiles.Keys;
-                TagList.Visibility = Visibility.Visible;
-                TagListFilter.Visibility = Visibility.Visible;
-                Close_Module.IsEnabled = true;
-                FileStreamOpen = true;
-                //show tag list, make clickable
+                try
+                {
+                    ModuleStream = new FileStream(ofd.FileName, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+                    Module = ModuleEditor.ReadModule(ModuleStream);
+                    TagList.ItemsSource = Module.ModuleFiles.Keys;
+                    TagList.Visibility = Visibility.Visible;
+                    TagListFilter.Visibility = Visibility.Visible;
+                    Close_Module.IsEnabled = true;
+                    FileStreamOpen = true;
+                    //show tag list, make clickable
+                }
+                catch // infinite is running
+                {
+                    MessageBox.Show("This File is open in another process", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
             }
         }
 
@@ -91,6 +98,8 @@ namespace InfiniteModuleEditor
         {
             if (TagListFilter.IsFocused)
                 return;
+            if (TagList.SelectedItem == null)
+                return;
 
             if (!TagOpen && FileStreamOpen)
             {
@@ -107,10 +116,13 @@ namespace InfiniteModuleEditor
                 CloseButton.Visibility = Visibility.Visible;
                 SaveAndCloseButton.Visibility = Visibility.Visible;
                 TagOpen = true;
+                // do the tag data filter when opening tag // alternatively you could reset that filter when opening
+                TagViewer.ItemsSource = ModuleFile.Tag.TagValues.ToList().FindAll(x => x.Name.Contains(TagSearch.Text) == true); 
             }
             else
             {
                 MessageBox.Show("You already have a tag open. Close it before opening another.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                TagList.SelectedItem = null;
             }
         }
 
@@ -168,7 +180,8 @@ namespace InfiniteModuleEditor
             TagSearch.Visibility = Visibility.Hidden;
             TagNameText.Visibility = Visibility.Hidden;
             TagOpen = false;
-            
+            TagList.SelectedItem = null;
+
         }
 
         private void SaveAndCloseButton_Click(object sender, RoutedEventArgs e)
@@ -186,6 +199,7 @@ namespace InfiniteModuleEditor
                 TagSearch.Visibility = Visibility.Hidden;
                 TagNameText.Visibility = Visibility.Hidden;
                 TagOpen = false;
+                TagList.SelectedItem = null;
             }
             else 
                 MessageBox.Show("Failed to compress tag to the right size");


### PR DESCRIPTION
- deselecting tag in taglist when you close that tag so you can reselect them without first opening another one
- do the tag data filter when opening tag, so you dont have to type and delete a letter, although you could decide to just wipe the filter everytime you open a tag
- popup error instead of crashing when opening a file that is currently open by another process
- grid splitter to slide the size of the two panels